### PR TITLE
Remove `.expect` from git code to prevent panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## 0.1.9
+
+### Fixed
+
+- Panics on failed git pull (remove `.expect`s)
+
 ## 0.1.8
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "crate_upd_bot"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "arraylib",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crate_upd_bot"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Waffle <waffle.lapkin@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Previously the worker thread was randomly dying presumably because of problems with the network.

An example of panic message: 
![image](https://user-images.githubusercontent.com/38225716/132506109-37b51b3d-bf3c-4339-a4e6-2efd0132d5c0.png)
