### PR TITLE
Only test stable ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,6 @@ name: Continuous integration
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: 
-          - stable
-          - beta
-          - nightly
-    
-        include:
-          - rust: stable
-            features: ""
-          - rust: beta
-            features: ""
-          - rust: nightly
-            features: "--all-features"
 
     steps:
       - uses: actions/checkout@v1
@@ -32,20 +18,20 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           override: true
       
       - name: build 
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --verbose ${{ matrix.features }}
+          args: --verbose
       
       - name: test 
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose ${{ matrix.features }}
+          args: --verbose
 
   clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR disables nightly and beta CI tests. For libraries it makes some sense to test on the bleeding edge, but for binaries I don't see why we'd need this.